### PR TITLE
Filedescriptors

### DIFF
--- a/examples/unix_fds.pl
+++ b/examples/unix_fds.pl
@@ -40,7 +40,7 @@ $dbus->get_message();
 my $recv_name = $dbus->get_unique_bus_name();
 
 my $pid = fork or do {
-    my $dbus = my $dbus = $> ? Protocol::DBus::Client::login_session() ? Protocol::DBus::Client::system();
+    my $dbus = $> ? Protocol::DBus::Client::login_session() : Protocol::DBus::Client::system();
 
     $dbus->initialize();
 

--- a/lib/Protocol/DBus/Client.pm
+++ b/lib/Protocol/DBus/Client.pm
@@ -216,6 +216,8 @@ sub init_pending_send {
 
 Boolean that indicates whether this client supports UNIX FD passing.
 
+This won't work unless you have loaded L<Socket::MsgHdr> in your code.
+
 =cut
 
 sub supports_unix_fd {


### PR DESCRIPTION
This fixes a small bug and adds a note about needing to separately load Socket::MsgHdr if passing FDs fails.

In my case, I didn't even seem to get an error returned from DBus when calling `org.freedesktop.login1.Manager->Inhibit` , and the error only showed up in the DBus monitor as
```
error time=1618737457.098490 sender=org.freedesktop.DBus -> destination=:1.11 error_name=org.freedesktop.DBus.Error.NotSupported reply_serial=44293
   string "Tried to send message with Unix file descriptorsto a client that doesn't support that."
```

I don't know if it is possible to surface that error to Perl, since it doesn't seem to get sent to the client at all.